### PR TITLE
Results can be null

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -252,6 +252,10 @@ class TNTSearchEngine extends Engine
      */
     public function mapIds($results)
     {
+        if (empty($results['ids'])) {
+            return collect();
+        }
+        
         return collect($results['ids'])->values();
     }
 


### PR DESCRIPTION
In the current situation it will error because of a reference to an array index on null. 
This fixes this issue.